### PR TITLE
[LIFECYCLE] Register Loopables

### DIFF
--- a/gomes.go
+++ b/gomes.go
@@ -1,7 +1,43 @@
 package gomesengine
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+
+	"github.com/mikabrytu/gomes-engine/screen"
+)
+
+var specs screen.Specs
+var running bool
 
 func HiGomes() {
 	fmt.Println("Hi Gomes!")
+}
+
+func Init() {
+	specs = screen.Specs{
+		Title:  "Gomes Engine",
+		Posx:   0,
+		Posy:   0,
+		Width:  800,
+		Height: 600,
+	}
+	screen.CreateScreen(specs)
+}
+
+func Run() {
+	running = true
+
+	go Destroy()
+
+	for running {
+		screen.Render()
+	}
+
+	screen.Destroy()
+}
+
+func Destroy() {
+	time.Sleep(5 * time.Second)
+	running = false
 }

--- a/gomes.go
+++ b/gomes.go
@@ -2,19 +2,20 @@ package gomesengine
 
 import (
 	"fmt"
-	"time"
 
+	"github.com/mikabrytu/gomes-engine/lifecycle"
 	"github.com/mikabrytu/gomes-engine/screen"
 )
 
 var specs screen.Specs
-var running bool
 
 func HiGomes() {
 	fmt.Println("Hi Gomes!")
 }
 
 func Init() {
+	lifecycle.Init()
+
 	specs = screen.Specs{
 		Title:  "Gomes Engine",
 		Posx:   0,
@@ -23,21 +24,12 @@ func Init() {
 		Height: 600,
 	}
 	screen.CreateScreen(specs)
+	lifecycle.Register(lifecycle.Loopable{
+		Update:  screen.Render,
+		Destroy: screen.Destroy,
+	})
 }
 
 func Run() {
-	running = true
-
-	go Destroy()
-
-	for running {
-		screen.Render()
-	}
-
-	screen.Destroy()
-}
-
-func Destroy() {
-	time.Sleep(5 * time.Second)
-	running = false
+	lifecycle.Run()
 }

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -2,7 +2,7 @@ package lifecycle
 
 import (
 	"container/list"
-	"time"
+	"fmt"
 )
 
 type Loopable struct {
@@ -40,6 +40,7 @@ func Stop(l Loopable) {
 	}
 
 	if loopables.Len() == 0 {
+		fmt.Println("There's no more loopables on the list. Quitting application")
 		running = false
 	}
 }
@@ -50,7 +51,5 @@ func Run() {
 			item := Loopable(e.Value.(Loopable))
 			item.Update()
 		}
-
-		time.Sleep(500 * time.Millisecond)
 	}
 }

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -6,8 +6,9 @@ import (
 )
 
 type Loopable struct {
-	Id     int
-	Update func()
+	Id      int
+	Update  func()
+	Destroy func()
 }
 
 var idCounter = 0
@@ -34,6 +35,7 @@ func Stop(l Loopable) {
 		item := Loopable(e.Value.(Loopable))
 
 		if l.Id == item.Id {
+			item.Destroy()
 			loopables.Remove(e)
 			break
 		}

--- a/screen/screen.go
+++ b/screen/screen.go
@@ -1,7 +1,6 @@
 package screen
 
 import (
-	"github.com/mikabrytu/gomes-engine/lifecycle"
 	"github.com/veandco/go-sdl2/sdl"
 )
 
@@ -13,34 +12,33 @@ type Specs struct {
 	Height int32
 }
 
-var loopable lifecycle.Loopable
+var window *sdl.Window
 
 func CreateScreen(s Specs) {
 	if err := sdl.Init(sdl.INIT_EVERYTHING); err != nil {
 		panic(err)
 	}
-	defer sdl.Quit()
 
-	window, err := sdl.CreateWindow(s.Title, s.Posx, s.Posy, s.Width, s.Height, sdl.WINDOW_SHOWN)
+	var err error
+	window, err = sdl.CreateWindow(s.Title, s.Posx, s.Posy, s.Width, s.Height, sdl.WINDOW_SHOWN)
 	if err != nil {
 		panic(err)
 	}
-	defer window.Destroy()
-
-	loopable = lifecycle.Loopable{Update: update}
-	lifecycle.Register(loopable)
-	lifecycle.Run()
 }
 
-func update() {
+func Render() {
 	for event := sdl.PollEvent(); event != nil; event = sdl.PollEvent() {
 		switch event.(type) {
 		case *sdl.QuitEvent:
 			println("Quit")
-			lifecycle.Stop(loopable)
 			break
 		}
 	}
 
 	sdl.Delay(33)
+}
+
+func Destroy() {
+	defer sdl.Quit()
+	defer window.Destroy()
 }

--- a/screen/screen.go
+++ b/screen/screen.go
@@ -21,14 +21,15 @@ func CreateScreen(s Specs) {
 	}
 	defer sdl.Quit()
 
-	window, err := sdl.CreateWindow("test", sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED, 800, 600, sdl.WINDOW_SHOWN)
+	window, err := sdl.CreateWindow(s.Title, s.Posx, s.Posy, s.Width, s.Height, sdl.WINDOW_SHOWN)
 	if err != nil {
 		panic(err)
 	}
 	defer window.Destroy()
 
 	loopable = lifecycle.Loopable{Update: update}
-	lifecycle.Run(loopable)
+	lifecycle.Register(loopable)
+	lifecycle.Run()
 }
 
 func update() {
@@ -36,7 +37,7 @@ func update() {
 		switch event.(type) {
 		case *sdl.QuitEvent:
 			println("Quit")
-			lifecycle.Stop()
+			lifecycle.Stop(loopable)
 			break
 		}
 	}

--- a/screen/screen.go
+++ b/screen/screen.go
@@ -31,6 +31,7 @@ func Render() {
 		switch event.(type) {
 		case *sdl.QuitEvent:
 			println("Quit")
+			Destroy()
 			break
 		}
 	}

--- a/test/main.go
+++ b/test/main.go
@@ -14,10 +14,12 @@ func main() {
 	gomesengine.HiGomes()
 
 	//testScreen()
-	testLifecycle()
+	//testLifecycle()
 }
 
 func testScreen() {
+	lifecycle.Init()
+
 	specs := screen.Specs{
 		Title:  "Gomes Demo",
 		Posx:   sdl.WINDOWPOS_UNDEFINED,

--- a/test/main.go
+++ b/test/main.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"fmt"
+	"time"
+
 	gomesengine "github.com/mikabrytu/gomes-engine"
+	"github.com/mikabrytu/gomes-engine/lifecycle"
 	"github.com/mikabrytu/gomes-engine/screen"
 	"github.com/veandco/go-sdl2/sdl"
 )
@@ -9,6 +13,11 @@ import (
 func main() {
 	gomesengine.HiGomes()
 
+	//testScreen()
+	testLifecycle()
+}
+
+func testScreen() {
 	specs := screen.Specs{
 		Title:  "Gomes Demo",
 		Posx:   sdl.WINDOWPOS_UNDEFINED,
@@ -17,4 +26,32 @@ func main() {
 		Height: 600,
 	}
 	screen.CreateScreen(specs)
+}
+
+func testLifecycle() {
+	l1 := lifecycle.Loopable{
+		Update: func() {
+			fmt.Println("Item 1 is in the Loop")
+		},
+	}
+
+	l2 := lifecycle.Loopable{
+		Update: func() {
+			fmt.Println("Item 2 is in the Loop")
+		},
+	}
+
+	lifecycle.Init()
+	l1 = lifecycle.Register(l1)
+	l2 = lifecycle.Register(l2)
+
+	go lifecycle.Run()
+
+	time.Sleep(2 * time.Second)
+	lifecycle.Stop(l1)
+
+	time.Sleep(2 * time.Second)
+	lifecycle.Stop(l2)
+
+	select {}
 }

--- a/test/main.go
+++ b/test/main.go
@@ -1,59 +1,11 @@
 package main
 
 import (
-	"fmt"
-	"time"
-
 	gomesengine "github.com/mikabrytu/gomes-engine"
-	"github.com/mikabrytu/gomes-engine/lifecycle"
-	"github.com/mikabrytu/gomes-engine/screen"
-	"github.com/veandco/go-sdl2/sdl"
 )
 
 func main() {
 	gomesengine.HiGomes()
-
-	//testScreen()
-	//testLifecycle()
-}
-
-func testScreen() {
-	lifecycle.Init()
-
-	specs := screen.Specs{
-		Title:  "Gomes Demo",
-		Posx:   sdl.WINDOWPOS_UNDEFINED,
-		Posy:   sdl.WINDOWPOS_UNDEFINED,
-		Width:  800,
-		Height: 600,
-	}
-	screen.CreateScreen(specs)
-}
-
-func testLifecycle() {
-	l1 := lifecycle.Loopable{
-		Update: func() {
-			fmt.Println("Item 1 is in the Loop")
-		},
-	}
-
-	l2 := lifecycle.Loopable{
-		Update: func() {
-			fmt.Println("Item 2 is in the Loop")
-		},
-	}
-
-	lifecycle.Init()
-	l1 = lifecycle.Register(l1)
-	l2 = lifecycle.Register(l2)
-
-	go lifecycle.Run()
-
-	time.Sleep(2 * time.Second)
-	lifecycle.Stop(l1)
-
-	time.Sleep(2 * time.Second)
-	lifecycle.Stop(l2)
-
-	select {}
+	gomesengine.Init()
+	gomesengine.Run()
 }


### PR DESCRIPTION
## What This PR Does
It adds the option to add _loopables_ to the lifecycle of the game, allowing operations like instantiate objects in runtime.

This PR also extracts the render loop from the screen creation, allowing the rendering management to happen during the loop of the game and unblocking the main thread

## Known Issues
The current _loopable_ system is not perfect, so it can block the main thread if the user starts to instantiate too much objects or if have delays involved. 
I'll add safe guards later to block the misuse of timers and irresponsible instantiations