### PR TITLE
[PHYSICS] Improve collision resolution

### DIFF
--- a/math/math.go
+++ b/math/math.go
@@ -4,3 +4,15 @@ type Vector2 struct {
 	X int
 	Y int
 }
+
+func ClampInt(n int) int {
+	if n < -1 {
+		return -1
+	}
+
+	if n > 1 {
+		return 1
+	}
+
+	return n
+}

--- a/physics/physics.go
+++ b/physics/physics.go
@@ -120,7 +120,7 @@ func CheckCollision(collider *RigidBody) RigidBody {
 	return result
 }
 
-func ResolveDynamicCollisions(body *RigidBody) {
+func ResolveDynamicCollisions(body *RigidBody, horizontal, vertical bool) {
 	if !body.IsDynamic {
 		fmt.Printf("Body %v is not set to Dynamic resolution.\n", body.Name)
 		return
@@ -132,19 +132,36 @@ func ResolveDynamicCollisions(body *RigidBody) {
 		return
 	}
 
-	if collision.Rect.PosX < body.Rect.PosX {
+	bMid := math.Vector2{
+		X: body.Rect.PosX + (body.Rect.Width / 2),
+		Y: body.Rect.PosY + (body.Rect.Height / 2),
+	}
+	cMid := math.Vector2{
+		X: collision.Rect.PosX + (collision.Rect.Width / 2),
+		Y: collision.Rect.PosY + (collision.Rect.Height / 2),
+	}
+
+	if horizontal && cMid.X == bMid.X {
+		body.Axis.X = 0
+	}
+
+	if vertical && cMid.Y == bMid.Y {
+		body.Axis.Y = 0
+	}
+
+	if cMid.X < bMid.X {
 		body.Axis.X = 1
 	}
 
-	if collision.Rect.PosX > body.Rect.PosX {
+	if cMid.X > bMid.X {
 		body.Axis.X = -1
 	}
 
-	if collision.Rect.PosY < body.Rect.PosY {
+	if cMid.Y < bMid.Y {
 		body.Axis.Y = 1
 	}
 
-	if collision.Rect.PosY > body.Rect.PosY {
+	if cMid.Y > bMid.Y {
 		body.Axis.Y = -1
 	}
 }


### PR DESCRIPTION
## What This PR Does
It improves the resolution of dynamic collisions and add an option for horizontal and vertical directions (90º, 180º, 270º and 360º).
The resolution now takes in consideration the center of the rect when deciding the new direction. 
This will help future calculations for motion and more elaborate physics resolution.

When running the `ResolveDynamicCollisions()`, the user now have the option to enable horizontal (axis.x = 0) or vertical (axis.y = 0) movement. The default value is `false`

Also adds a math function to **clamp** integers between -1 and 1