### PR TITLE
[LIFECYCLE][FIX] Crash when stopping game objects

### DIFF
--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -58,7 +58,10 @@ func Stop(o GameObject) {
 		item := GameObject(e.Value.(GameObject))
 
 		if o.Id == item.Id {
-			item.Destroy()
+			if item.Destroy != nil {
+				item.Destroy()
+			}
+
 			objects.Remove(e)
 			break
 		}
@@ -156,8 +159,6 @@ func Run() {
 		sdl.Delay(15)
 	}
 }
-
-// Private Implementation
 
 func registerSpecial(o GameObject, message string) GameObject {
 	if isGameObjectNil(o) {


### PR DESCRIPTION
## The Problem
There was a null validation missing from the `Stop()` function when an object was about to get removed from the list, causing the crash

```go
item.Destroy()
objects.Remove(e)
```

## The Solution
Adding a simple null validation skip the function call if the object doesn't have a function registered

```go
if item.Destroy != nil {
  item.Destroy()
}

objects.Remove(e)
```