### PR TITLE
[UI][FIX] Overlapping text

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -51,7 +51,7 @@ func Render() {
 
 	if (renderCopies != nil) && (renderCopies.Len() > 0) {
 		for e := renderCopies.Front(); e != nil; e = e.Next() {
-			specs := e.Value.(CopySpecs)
+			specs := e.Value.(*CopySpecs)
 			renderer.Copy(specs.Texture, nil, &specs.Rect)
 		}
 	}
@@ -74,13 +74,13 @@ func DrawSimpleShapes(shape utils.RectSpecs, color Color) {
 	renderer.FillRect(&rect)
 }
 
-func RenderCopy(copy CopySpecs) {
+func RenderCopy(copy *CopySpecs) {
 	if renderCopies == nil {
 		renderCopies = list.New()
 	}
 
 	for e := renderCopies.Front(); e != nil; e = e.Next() {
-		if e.Value.(CopySpecs) == copy {
+		if e.Value.(*CopySpecs) == copy {
 			return
 		}
 	}

--- a/ui/font.go
+++ b/ui/font.go
@@ -73,7 +73,7 @@ func (f *Font) Init(text string, color render.Color, position math.Vector2) {
 			}
 		},
 		Render: func() {
-			render.RenderCopy(f.copy)
+			render.RenderCopy(&f.copy)
 		},
 		Destroy: func() {
 			f.ClearFont()


### PR DESCRIPTION
## The Problem
When a font was updated through the `font.UpdateText()` function, the text sometimes overlaps with itself.
The cause was on the `RenderCopy()` function. Because the copy list on the **Render** layer was not storing _pointers_ but font values instead, new instances of the same font was created on every update.

```go

func RenderCopy(copy CopySpecs) {
    if renderCopies == nil {
        renderCopies = list.New()
    }

    for e := renderCopies.Front(); e != nil; e = e.Next() {
        if e.Value.(CopySpecs) == copy {
            return
        }
    }

    renderCopies.PushBack(copy)
}
```

## The Solution
Changed the function to receive pointers instead of pure values fixed the problem

```go

func RenderCopy(copy *CopySpecs)
```