### PR TITLE
[LIFECYCLE][FIX] New game objects can't call Start

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -23,7 +23,7 @@ func ListenToInput() {
 			handleKeyboard(event.(*sdl.KeyboardEvent))
 		case *sdl.QuitEvent:
 			println("Quit")
-			lifecycle.StopFirst()
+			lifecycle.StopInput()
 			return
 		}
 	}
@@ -34,9 +34,9 @@ func handleMouse(e *sdl.MouseButtonEvent) {
 
 	switch e.State {
 	case sdl.PRESSED:
-		events.Emit(events.INPUT_MOUSE_CLICK_DOWN, e.X, e.Y)
+		events.Emit(events.INPUT_MOUSE_CLICK_DOWN, int(e.X), int(e.Y))
 	case sdl.RELEASED:
-		events.Emit(events.INPUT_MOUSE_CLICK_UP, e.X, e.Y)
+		events.Emit(events.INPUT_MOUSE_CLICK_UP, int(e.X), int(e.Y))
 	}
 }
 

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -15,6 +15,7 @@ type GameObject struct {
 	Physics func()
 	Render  func()
 	Destroy func()
+	started bool
 }
 
 var idCounter = 0
@@ -34,8 +35,9 @@ func Init() {
 	smoothing = 0.5
 }
 
-func Register(o GameObject) GameObject {
+func Register(o *GameObject) *GameObject {
 	o.Id = idCounter
+	o.started = false
 	idCounter++
 
 	_ = objects.PushFront(o)
@@ -51,11 +53,11 @@ func RegisterRender(o GameObject) {
 	renderLayer = registerSpecial(o, "Last")
 }
 
-func Stop(o GameObject) {
+func Stop(o *GameObject) {
 	var next *list.Element
 	for e := objects.Front(); e != nil; e = next {
 		next = e.Next()
-		item := GameObject(e.Value.(GameObject))
+		item := e.Value.(*GameObject)
 
 		if o.Id == item.Id {
 			if item.Destroy != nil {
@@ -74,11 +76,11 @@ func Stop(o GameObject) {
 }
 
 func StopById(id int) {
-	l := GameObject{Id: id}
-	Stop(l)
+	o := &GameObject{Id: id}
+	Stop(o)
 }
 
-func StopFirst() {
+func StopInput() {
 	if inputLayer.Destroy != nil {
 		inputLayer.Destroy()
 	}
@@ -86,7 +88,7 @@ func StopFirst() {
 	inputLayer = GameObject{}
 }
 
-func StopLast() {
+func StopRender() {
 	if renderLayer.Destroy != nil {
 		renderLayer.Destroy()
 	}
@@ -102,51 +104,61 @@ func Kill() {
 }
 
 func Run() {
-	if running {
-		if inputLayer.Start != nil {
+	for running {
+		/* Start() */
+		if inputLayer.Start != nil && !inputLayer.started {
 			inputLayer.Start()
+			inputLayer.started = true
 		}
 
 		for e := objects.Front(); e != nil; e = e.Next() {
-			item := GameObject(e.Value.(GameObject))
-			if item.Start != nil {
+			item := e.Value.(*GameObject)
+			if item.Start != nil && !item.started {
 				item.Start()
+				item.started = true
 			}
 		}
 
-		if renderLayer.Start != nil {
+		if renderLayer.Start != nil && !renderLayer.started {
 			renderLayer.Start()
+			renderLayer.started = true
 		}
-	}
+		/* Start() */
 
-	for running {
+		/* FPS Calculation */
 		now := time.Now()
 		delta := now.Sub(prevTime).Seconds()
 		prevTime = now
 
 		current := 1 / delta
 		fps = fps*smoothing + current*(1-smoothing)
+		/* FPS Calculation */
 
+		/* Update() */
 		if inputLayer.Update != nil {
 			inputLayer.Update()
 		}
 
 		for e := objects.Front(); e != nil; e = e.Next() {
-			item := GameObject(e.Value.(GameObject))
+			item := e.Value.(*GameObject)
 			if item.Update != nil {
 				item.Update()
 			}
 		}
+		/* Update() */
 
+		/* Physics() */
 		for e := objects.Front(); e != nil; e = e.Next() {
-			item := GameObject(e.Value.(GameObject))
+			item := e.Value.(*GameObject)
 			if item.Physics != nil {
 				item.Physics()
 			}
 		}
+		/* Physics() */
 
+		/* Render() */
 		for e := objects.Front(); e != nil; e = e.Next() {
-			item := GameObject(e.Value.(GameObject))
+			item := e.Value.(*GameObject)
 			if item.Render != nil {
 				item.Render()
 			}
@@ -166,6 +178,7 @@ func registerSpecial(o GameObject, message string) GameObject {
 		panic(m)
 	}
 
+	o.started = false
 	return o
 }
 

--- a/render/render.go
+++ b/render/render.go
@@ -44,7 +44,7 @@ func Render() {
 		switch event.(type) {
 		case *sdl.QuitEvent:
 			println("Quit")
-			lifecycle.StopLast()
+			lifecycle.StopRender()
 			return
 		}
 	}

--- a/test/main.go
+++ b/test/main.go
@@ -5,7 +5,10 @@ import (
 	"time"
 
 	gomesengine "github.com/mikabrytu/gomes-engine"
+	"github.com/mikabrytu/gomes-engine/events"
+	"github.com/mikabrytu/gomes-engine/render"
 	savesystem "github.com/mikabrytu/gomes-engine/systems/save"
+	"github.com/mikabrytu/gomes-engine/utils"
 
 	"github.com/mikabrytu/gomes-engine/lifecycle"
 	"github.com/mikabrytu/gomes-engine/math"
@@ -22,8 +25,7 @@ func main() {
 
 	lifecycle.SetSmoothStep(0.9)
 
-	//save()
-	//load()
+	instantiate()
 
 	gomesengine.Run()
 }
@@ -31,6 +33,35 @@ func main() {
 type Score struct {
 	Score     int       `json:"score"`
 	Timestamp time.Time `json:"timestamp"`
+}
+
+func instantiate() {
+	events.Subscribe(events.INPUT_MOUSE_CLICK_DOWN, func(params ...any) error {
+		pos := math.Vector2{
+			X: params[0].([]any)[0].([]any)[0].(int),
+			Y: params[0].([]any)[0].([]any)[1].(int),
+		}
+
+		fmt.Printf("%v\n", pos)
+
+		rect := utils.RectSpecs{
+			Width:  50,
+			Height: 50,
+			PosX:   pos.X,
+			PosY:   pos.Y,
+		}
+
+		lifecycle.Register(&lifecycle.GameObject{
+			Start: func() {
+				println("Cube started!")
+			},
+			Render: func() {
+				render.DrawSimpleShapes(rect, render.White)
+			},
+		})
+
+		return nil
+	})
 }
 
 func save() {

--- a/ui/font.go
+++ b/ui/font.go
@@ -63,7 +63,7 @@ func (f *Font) Init(text string, color render.Color, position math.Vector2) {
 	f.position = position
 	f.prepareRender()
 
-	lifecycle.Register(lifecycle.GameObject{
+	lifecycle.Register(&lifecycle.GameObject{
 		Update: func() {
 			if f.update {
 				f.update = false


### PR DESCRIPTION
## The Problem
_GameObjects_ instantiated at runtime was not calling the `Start()` function because the logic inside the _Lifecycle_ layer that cover that part only happened at the first frame of the game loop.

## The Solution
The `Start()` call logic was moved to inside the game loop and a `started` flag checks if the object has already ran it.

For that to work, all the references to _GameObjects_ inside the lifecycle was changed to pointers, so the actual _GameObject_ can change the flag after the `Start()` call.

**THIS UPDATE WILL CAUSE CRASHES** on projects using version 1.2.7-dev or below since all code registering new `GameObjects` must include the `**&**` notation on the `Register()` function

### Additional Notes
The values returned by the mouse click event was changed to `int`, instead of `int32` to simplify usage