### PR TITLE
[LIFECYCLE][FIX] Fix new rigidbody crash

### DIFF
--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -45,6 +45,10 @@ func Register(o *GameObject) *GameObject {
 
 	_ = objects.PushFront(o)
 
+	if debug.IsEnabled() {
+		fmt.Printf("Object %v was registered in lifecycle\n", o.Id)
+	}
+
 	return o
 }
 
@@ -159,7 +163,12 @@ func Run() {
 
 		for e := objects.Front(); e != nil; e = e.Next() {
 			item := e.Value.(*GameObject)
-			if item.Update != nil && !item.skip {
+
+			if !item.started || item.skip {
+				continue
+			}
+
+			if item.Update != nil {
 				item.Update()
 			}
 		}
@@ -168,7 +177,12 @@ func Run() {
 		/* Physics() */
 		for e := objects.Front(); e != nil; e = e.Next() {
 			item := e.Value.(*GameObject)
-			if item.Physics != nil && !item.skip {
+
+			if !item.started || item.skip {
+				continue
+			}
+
+			if item.Physics != nil {
 				item.Physics()
 			}
 		}
@@ -177,7 +191,11 @@ func Run() {
 		/* Render() */
 		for e := objects.Front(); e != nil; e = e.Next() {
 			item := e.Value.(*GameObject)
-			if item.Render != nil && !item.skip {
+			if !item.started || item.skip {
+				continue
+			}
+
+			if item.Render != nil {
 				item.Render()
 			}
 		}


### PR DESCRIPTION
## The Problem
**GameObjects** instantiated in real time was calling other functions like `Update()` or `Physics()` before the initial `Start()`, causing crashes when creating new rigid bodies, since the check for collision step was happening before the body was registered

## The Solution
Before running those functions, a validation was added to check if the object was started to make sure the lifecycle order is working as intended

```go
if !item.started || item.skip {
	continue
}
```