### PR TITLE
[LIFECYCLE] Add StopAll option

### DIFF
--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -82,16 +82,23 @@ func Stop(o *GameObject) {
 
 	if objects.Len() == 0 {
 		if debug.IsEnabled() {
-			fmt.Println("There's no more loopables on the list. Quitting application")
+			fmt.Println("There's no more loopables on the list")
 		}
-
-		running = false
 	}
 }
 
 func StopById(id int) {
 	o := &GameObject{Id: id}
 	Stop(o)
+}
+
+func StopAll() {
+	for e := objects.Front(); e != nil; {
+		next := e.Next()
+		o := e.Value.(*GameObject)
+		Stop(o)
+		e = next
+	}
 }
 
 func StopInput() {


### PR DESCRIPTION
## What This PR Does
It adds the option to stop all current **GameObjects** alive.
It also removes the `running = false` from the `Stop()` function so the application doesn't quit when cleaning the list