### PR TITLE
[RENDER] Circle Shapes

### DIFF
--- a/render/draw.go
+++ b/render/draw.go
@@ -2,6 +2,7 @@ package render
 
 import (
 	"github.com/mikabrytu/gomes-engine/utils"
+	"github.com/veandco/go-sdl2/gfx"
 	"github.com/veandco/go-sdl2/sdl"
 )
 
@@ -16,4 +17,12 @@ func DrawRect(shape utils.RectSpecs, color Color) {
 	renderer.SetDrawColor(color.R, color.G, color.B, color.A)
 	renderer.DrawRect(&rect)
 	renderer.FillRect(&rect)
+}
+
+func DrawCircle(shape utils.CircleSpecs, color Color) {
+	x := int32(shape.PosX)
+	y := int32(shape.PosY)
+	r := int32(shape.Radius)
+
+	gfx.FilledCircleRGBA(renderer, x, y, r, color.R, color.G, color.B, color.A)
 }

--- a/test/main.go
+++ b/test/main.go
@@ -27,38 +27,25 @@ func main() {
 		return nil
 	})
 
-	tint()
+	circle()
 
 	gomesengine.Run()
 }
 
-func tint() {
+func circle() {
+	circle := utils.CircleSpecs{
+		PosX:   SCREEN_SIZE.X / 2,
+		PosY:   SCREEN_SIZE.Y / 2,
+		Radius: 32,
+	}
+
 	lifecycle.Register(&lifecycle.GameObject{
-		Start: func() {
-			specs := utils.RectSpecs{
-				PosX:   0,
-				PosY:   0,
-				Width:  128,
-				Height: 128,
-			}
-
-			s1 := render.NewSprite("sprite1", "test/assets/img/square.png")
-			s1.Init(specs, render.Transparent)
-
-			specs.PosX = 128
-
-			s2 := render.NewSprite("sprite2", "test/assets/img/square.png")
-			s2.Init(specs, render.Yellow)
-
-			events.Subscribe(events.INPUT_MOUSE_CLICK, func(params ...any) error {
-				println("Clicked")
-
-				specs.PosY = 128
-				s2.UpdateRect(specs)
-				s2.UpdateColor(render.Red)
-
-				return nil
-			})
+		Update: func() {
+			circle.PosX += 1
+			circle.PosY += 1
+		},
+		Render: func() {
+			render.DrawCircle(circle, render.White)
 		},
 	})
 }

--- a/utils/shapes.go
+++ b/utils/shapes.go
@@ -6,3 +6,9 @@ type RectSpecs struct {
 	Width  int
 	Height int
 }
+
+type CircleSpecs struct {
+	PosX   int
+	PosY   int
+	Radius int
+}


### PR DESCRIPTION
## What This PR Does
It adds the [SDL2 GFX](https://pkg.go.dev/github.com/veandco/go-sdl2@v0.4.40/gfx) package to enable the usage of primitives like circles.
The current implementation only add **filled circles** and add a `Circle` struct to be used, such as the `Rect` shape