### PR TITLE
[RENDER] Fix Crash On Sprite Clear

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -21,6 +21,7 @@ type CopySpecs struct {
 	Rect    sdl.Rect
 	Color   Color
 	Update  bool
+	Render  bool
 }
 
 var window *sdl.Window
@@ -67,7 +68,9 @@ func Render() {
 				}
 			}
 
-			renderer.Copy(specs.Texture, nil, &specs.Rect)
+			if specs.Render {
+				renderer.Copy(specs.Texture, nil, &specs.Rect)
+			}
 		}
 	}
 
@@ -88,6 +91,20 @@ func AddToRenderer(copy *CopySpecs) {
 	}
 
 	renderCopies.PushBack(copy)
+}
+
+func RemoveFromRenderer(copy *CopySpecs) {
+	if renderCopies == nil {
+		renderCopies = list.New()
+	}
+
+	for e := renderCopies.Front(); e != nil; e = e.Next() {
+		if e.Value.(*CopySpecs) == copy {
+			renderCopies.Remove(e)
+
+			return
+		}
+	}
 }
 
 func GetRenderer() *sdl.Renderer {

--- a/render/sprite.go
+++ b/render/sprite.go
@@ -68,6 +68,7 @@ func (s *Sprite) GetRect() utils.RectSpecs {
 }
 
 func (s *Sprite) ClearSprite() {
+	RemoveFromRenderer(&s.copy)
 	s.texture.Destroy()
 }
 

--- a/render/sprite.go
+++ b/render/sprite.go
@@ -36,6 +36,18 @@ func (s *Sprite) Init() {
 	AddToRenderer(&s.copy)
 }
 
+func (s *Sprite) Enable() {
+	s.copy.Render = true
+}
+
+func (s *Sprite) Disable() {
+	s.copy.Render = false
+}
+
+func (s *Sprite) IsEnabled() bool {
+	return s.copy.Render
+}
+
 func (s *Sprite) UpdateRect(rect utils.RectSpecs) {
 	s.rect = rect
 	s.newRect()
@@ -78,5 +90,6 @@ func (s *Sprite) newRect() {
 		},
 		Color:  s.color,
 		Update: true,
+		Render: true,
 	}
 }

--- a/test/main.go
+++ b/test/main.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"fmt"
-
 	gomesengine "github.com/mikabrytu/gomes-engine"
 
 	"github.com/mikabrytu/gomes-engine/debug"
 	"github.com/mikabrytu/gomes-engine/events"
 	"github.com/mikabrytu/gomes-engine/lifecycle"
 	"github.com/mikabrytu/gomes-engine/math"
+	"github.com/mikabrytu/gomes-engine/render"
+	"github.com/mikabrytu/gomes-engine/utils"
 )
 
 var SCREEN_SIZE = math.Vector2{
@@ -24,28 +24,41 @@ func main() {
 	debug.EnableDebug()
 	lifecycle.SetSmoothStep(0.9)
 
-	events.Subscribe(events.Input, events.INPUT_MOUSE_CLICK, func(data any) {
-		click := data.(events.InputMouseClickEvent)
-
-		index := ""
-		if click.Index.Left == 1 {
-			index = "left"
-		}
-		if click.Index.Right == 1 {
-			index = "right"
-		}
-		if click.Index.Middle == 1 {
-			index = "middle"
-		}
-
-		message := fmt.Sprintf("Clicked at position {%d, %d} with button %v\n", click.Position.X, click.Position.Y, index)
-		print(message)
+	path := "test/assets/img/alien.png"
+	rect := utils.RectSpecs{
+		PosX:   (SCREEN_SIZE.X / 2) - 32,
+		PosY:   (SCREEN_SIZE.Y / 2) - 32,
+		Width:  64,
+		Height: 64,
+	}
+	sprite := render.NewSprite("Sprite", path, rect, render.White)
+	game_object := lifecycle.Register(&lifecycle.GameObject{
+		Start: func() {
+			sprite.Init()
+		},
+		Render: func() {
+			render.DrawRect(rect, render.White)
+		},
 	})
 
-	events.Subscribe(events.Input, events.INPUT_MOUSE_MOVE, func(data any) {
-		move := data.(events.InputMouseMoveEvent)
-		message := fmt.Sprintf("Mouse moving. Current position {%d, %d}\n", move.Position.X, move.Position.Y)
-		print(message)
+	// Event Listeners
+
+	events.Subscribe(events.Input, events.INPUT_KEYBOARD_PRESSED_ESCAPE, func(data any) {
+		lifecycle.Kill()
+	})
+
+	events.Subscribe(events.Input, events.INPUT_MOUSE_CLICK_DOWN, func(data any) {
+		click := data.(events.InputMouseClickDownEvent)
+
+		if click.Index.Left == 1 {
+			sprite.Disable()
+			lifecycle.Disable(game_object)
+		}
+
+		if click.Index.Right == 1 {
+			sprite.Enable()
+			lifecycle.Enable(game_object)
+		}
 	})
 
 	gomesengine.Run()


### PR DESCRIPTION
## What This PR Does
It fixes a memory leak when trying to render a texture that was destroyed.

It also adds a better control of render for sprites by adding an option to skip the rendering per frame by using the functions `Enable()` and `Disable()` for sprites

### The Problem
After using `sprite.ClearSprite()` function, the texture was destroyed by the pointer was still registered in the list of textures on the render layer, so when an attempt to render the copy happened, the application crashed.

### The Solution
When clearing a sprite and destroying a texture, it's related copy is also removed from the render list