### PR TITLE
[RENDER] Fix Draw Rect Function

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -78,6 +78,14 @@ func Render() {
 		}
 	}
 
+	// The renderer presents the textures of the previous frame
+	// so the draw rect function can work without a refactor
+	renderer.Present()
+
+	destroySprites()
+	destroyFonts()
+
+	// Now the next frame is prepared before rendered
 	renderer.SetDrawColor(
 		backgroundColor.R,
 		backgroundColor.G,
@@ -138,11 +146,6 @@ func Render() {
 			copy.rect,
 		)
 	}
-
-	renderer.Present()
-
-	destroySprites()
-	destroyFonts()
 }
 
 func RegisterSprite(sprite *Sprite) {

--- a/test/main.go
+++ b/test/main.go
@@ -62,6 +62,9 @@ func main() {
 
 			font.AlignText(anchor, offset)
 		},
+		Render: func() {
+			render.DrawRect(utils.RectSpecs{PosX: 0, PosY: 128, Width: 256, Height: 32}, render.Green)
+		},
 		Destroy: func() {
 			sprite.Clear()
 			font.Clear()


### PR DESCRIPTION
### The Problem
**Rects** drawn by `DrawRect()` function are not rendering anymore. 
This happens because the new render pipeline clears all screen data before presenting the rects created in runtime

### The Solution
Caching the render data to the next frame and flushing it before all the new frame's texture creation happens solves it, since the `Present()` now is called before `Clear()`