### PR TITLE
[RENDER] Order of Rendering

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -1,6 +1,9 @@
 package render
 
 import (
+	"fmt"
+	"sort"
+
 	"github.com/mikabrytu/gomes-engine/debug"
 	"github.com/mikabrytu/gomes-engine/lifecycle"
 	"github.com/mikabrytu/gomes-engine/utils"
@@ -32,12 +35,13 @@ type CopyFont struct {
 var window *sdl.Window
 var renderer *sdl.Renderer
 
-var spriteCreateQueue []*Sprite
+var spriteCreateQueue map[int]*Sprite
 var spriteDestroyQueue []*Sprite
 var fontCreateQueue []*Font
 var fontDestroyQueue []*Font
-var spriteCopies []CopySprite
+var spriteCopies map[int]CopySprite
 var fontCopies []CopyFont
+var orderKeys []int
 
 var backgroundColor Color
 
@@ -54,12 +58,13 @@ func CreateScreen(s ScreenSpecs) {
 		panic(err)
 	}
 
-	spriteCreateQueue = make([]*Sprite, 0)
+	spriteCreateQueue = make(map[int]*Sprite)
 	spriteDestroyQueue = make([]*Sprite, 0)
 	fontCreateQueue = make([]*Font, 0)
 	fontDestroyQueue = make([]*Font, 0)
-	spriteCopies = make([]CopySprite, 0)
+	spriteCopies = make(map[int]CopySprite, 0)
 	fontCopies = make([]CopyFont, 0)
+	orderKeys = make([]int, 0)
 
 	backgroundColor = Black
 }
@@ -97,7 +102,13 @@ func Render() {
 	createSprites()
 	createFonts()
 
-	for _, copy := range spriteCopies {
+	for _, key := range orderKeys {
+		copy := spriteCopies[key]
+
+		if copy.sprite == nil {
+			continue
+		}
+
 		if copy.sprite.enabled == false {
 			continue
 		}
@@ -157,7 +168,11 @@ func Render() {
 }
 
 func RegisterSprite(sprite *Sprite) {
-	spriteCreateQueue = append(spriteCreateQueue, sprite)
+	if debug.IsEnabled() {
+		println(fmt.Sprintf("::RegisterSprite:: -> sprite name: %v | order: %v", sprite.name, sprite.order))
+	}
+
+	spriteCreateQueue[sprite.order] = sprite
 }
 
 func RegisterFont(font *Font) {
@@ -192,7 +207,9 @@ func createSprites() {
 		return
 	}
 
-	for _, sprite := range spriteCreateQueue {
+	for key := range spriteCreateQueue {
+		sprite := spriteCreateQueue[key]
+
 		texture, err := img.LoadTexture(renderer, sprite.path)
 		if err != nil {
 			panic(err)
@@ -209,10 +226,22 @@ func createSprites() {
 			},
 			color: sprite.color,
 		}
-		spriteCopies = append(spriteCopies, copy)
+
+		spriteCopies[key] = copy
+
+		if debug.IsEnabled() {
+			println(fmt.Sprintf("::createSprites:: -> Copy of sprite %v is created and added to copy collection at key %v", sprite.name, key))
+		}
 	}
 
-	spriteCreateQueue = spriteCreateQueue[:0]
+	for key := range spriteCreateQueue {
+		orderKeys = append(orderKeys, key)
+	}
+	sort.Ints(orderKeys)
+
+	for key := range spriteCreateQueue {
+		delete(spriteCreateQueue, key)
+	}
 }
 
 func createFonts() {
@@ -269,7 +298,9 @@ func destroySprites() {
 	}
 
 	for _, sprite := range spriteDestroyQueue {
-		for i, copy := range spriteCopies {
+		for key := range spriteCopies {
+			copy := spriteCopies[key]
+
 			if copy.sprite != sprite {
 				continue
 			}
@@ -279,7 +310,7 @@ func destroySprites() {
 				panic(err)
 			}
 
-			spriteCopies = append(spriteCopies[:i], spriteCopies[i+1:]...)
+			delete(spriteCopies, key)
 			break
 		}
 	}

--- a/render/sprite.go
+++ b/render/sprite.go
@@ -9,16 +9,18 @@ type Sprite struct {
 	path    string
 	rect    utils.RectSpecs
 	color   Color
+	order   int
 	enabled bool
 	update  bool
 }
 
-func NewSprite(name string, path string, rect utils.RectSpecs, color Color) *Sprite {
+func NewSprite(name string, path string, rect utils.RectSpecs, color Color, order int) *Sprite {
 	sprite := &Sprite{
 		name:    name,
 		path:    path,
 		rect:    rect,
 		color:   color,
+		order:   order,
 		enabled: true,
 		update:  false,
 	}

--- a/test/main.go
+++ b/test/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"math/rand"
-
 	gomesengine "github.com/mikabrytu/gomes-engine"
 
 	"github.com/mikabrytu/gomes-engine/debug"
@@ -29,70 +27,38 @@ func main() {
 		lifecycle.Kill()
 	})
 
-	objs := make([]*obj, 0)
-	events.AddListener(events.Input, events.INPUT_KEYBOARD_PRESSED_F, func(data any) {
-		println()
-		objs = append(objs, New())
-	})
+	rect := utils.RectSpecs{
+		PosX:   (SCREEN_SIZE.X / 2) - 64,
+		PosY:   (SCREEN_SIZE.Y / 2) - 64,
+		Width:  128,
+		Height: 128,
+	}
 
-	events.AddListener(events.Input, events.INPUT_KEYBOARD_PRESSED_SPACE, func(data any) {
-		index := rand.Intn(len(objs))
-		o := objs[index]
+	sprite_1 := render.NewSprite("sprite-1", "test/assets/img/mario.png", rect, render.White, 1)
+	sprite_1.Init()
+	sprite_1.Enable()
 
-		if o != nil {
-			lifecycle.Stop(o.Instace)
-			o = nil
-		} else {
-			println("Nil object. Try again")
-		}
+	rect_2 := rect
+	rect_2.PosX += 64
+	rect_2.PosY += 64
+
+	sprite_2 := render.NewSprite("sprite-2", "test/assets/img/alien2.jpg", rect_2, render.White, 3)
+	sprite_2.Init()
+	sprite_2.Enable()
+
+	rect_3 := rect_2
+	rect_3.PosX += 64
+	rect_3.PosY += 64
+
+	sprite_3 := render.NewSprite("sprite-3", "test/assets/img/alien.png", rect_3, render.White, 2)
+	sprite_3.Init()
+	sprite_3.Enable()
+
+	events.AddListener(events.Input, events.INPUT_KEYBOARD_PRESSED_ENTER, func(data any) {
+		sprite_1.Clear()
+		sprite_2.Clear()
+		sprite_3.Clear()
 	})
 
 	gomesengine.Run()
-}
-
-type obj struct {
-	Instace  *lifecycle.GameObject
-	Listener *events.EventListener
-	rect     utils.RectSpecs
-	name     string
-	color    render.Color
-}
-
-func New() *obj {
-	obj := &obj{
-		rect: utils.RectSpecs{
-			PosX:   rand.Intn(SCREEN_SIZE.X - 64),
-			PosY:   rand.Intn(SCREEN_SIZE.Y - 64),
-			Width:  64,
-			Height: 64,
-		},
-	}
-
-	obj.Listener = &events.EventListener{Id: 1001}
-	obj.Instace = lifecycle.Register(&lifecycle.GameObject{
-		Start: func() {
-			obj.Listener = events.AddListener(events.Input, events.INPUT_MOUSE_CLICK_DOWN, func(data any) {
-				click := data.(events.InputMouseClickDownEvent)
-
-				if click.Position.X > obj.rect.PosX && click.Position.X < (obj.rect.PosX+obj.rect.Width) &&
-					click.Position.Y > obj.rect.PosY && click.Position.Y < (obj.rect.PosY+obj.rect.Height) {
-					println("clicked at", obj.name)
-				}
-
-			})
-		},
-		Destroy: func() {
-			println("Removing Listener ", obj.Listener.Id)
-			events.RemoveListener(events.Input, events.INPUT_MOUSE_CLICK_DOWN, obj.Listener.Id)
-		},
-		Render: func() {
-			render.DrawRect(obj.rect, render.White)
-		},
-	})
-
-	return obj
-}
-
-func (o *obj) GetListenerId() uint64 {
-	return o.Listener.Id
 }


### PR DESCRIPTION
## What This PR Does
It adds a order of execution logic for sprites when rendering them. Now, when a Sprite is create with `render.NewSprite()`, the last parameter defines the order in which the sprite will be displayed in relation to the other sprites.

### Important Notes
Because the order is used as a key in `map[int]*Sprite`, if multiple sprites are registered with the same order, only one will be rendered