### PR TITLE
[RENDER] Hotfix: Duplicated Textures

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -311,6 +311,14 @@ func destroySprites() {
 			}
 
 			delete(spriteCopies, key)
+
+			for i, k := range orderKeys {
+				if k == key {
+					orderKeys = append(orderKeys[:i], orderKeys[i+1:]...)
+					break
+				}
+			}
+
 			break
 		}
 	}


### PR DESCRIPTION
### The Problem
After the addition of rendering order for sprites, when trying to update it's texture using `sprite.UpdateImage()` the old texture was still visible on screen. This happens because both textures use the same order which is the key of the map of sprites causing conflict in the collection. So when iterating through the render loop, both textures was still in memory causing the glitch

### The Solution
Removing the sprite key from the collection of keys when a texture is clear from memory in the `destroySprites()` function was enough to avoid multiple textures on the same order (or map key)

```go

if k == key {
	orderKeys = append(orderKeys[:i], orderKeys[i+1:]...)
	break
}

```