### PR TITLE
[INPUT] Fix Event Emission Crash

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -1,5 +1,7 @@
 package events
 
+import "github.com/mikabrytu/gomes-engine/debug"
+
 type EventLayer int
 
 const (
@@ -28,6 +30,14 @@ func Init() {
 }
 
 func Emit(layer EventLayer, event any) {
+	if event == nil {
+		if debug.IsEnabled() {
+			println("Event is not valid")
+		}
+
+		return
+	}
+
 	switch layer {
 	case Audio:
 		publishAsync(audioBus, event.(Event))


### PR DESCRIPTION
## The Problem
When triggering a Event that could not be converted to an interface, the event system panics and crash the application

```go
event.(Event) // if the conversion fails, the application crashes
```

## The Solution
Adding a nil check before trying to convert solves the problem. There's even a debug message communicating the issue

```go
if event == nil {
	if debug.IsEnabled() {
		println("Event is not valid")
	}

	return
}
```